### PR TITLE
Update jsDelivr link

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ Include `aping-plugin-youtube.min.js` in your apiNG application
 <script src="node_modules/aping-plugin-youtube/dist/aping-plugin-youtube.min.js"></script>
 
 <!-- when using cdn file -->
-<script src="//cdn.jsdelivr.net/aping.plugin-youtube/latest/aping-plugin-youtube.min.js"></script>
+<script src="//cdn.jsdelivr.net/npm/aping-plugin-youtube@latest/dist/aping-plugin-youtube.min.js"></script>
 
 <!-- when using downloaded files -->
 <script src="aping-plugin-youtube.min.js"></script>

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "aping-plugin-youtube",
   "version": "0.7.12",
   "description": "Youtube plugin for apiNG",
-  "main": "dist/angular-plugin-youtube.min.js",
+  "main": "dist/aping-plugin-youtube.min.js",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"
   },


### PR DESCRIPTION
[jsDelivr switched to a fully automated system](https://www.jsdelivr.com/features), that can serve files from npm and GitHub. This means all future releases will be available automatically, but will use a new link structure.

I updated the link now so you don't forget to do it when you release a new version.

You can find links for all files at https://www.jsdelivr.com/package/npm/aping-plugin-youtube.

Feel free to ping me if you have any questions regarding this change.